### PR TITLE
ci: use ubuntu 24.04 on github action

### DIFF
--- a/.github/workflows/label.yaml
+++ b/.github/workflows/label.yaml
@@ -4,7 +4,7 @@ on: [pull_request_target]
 
 jobs:
   labeler:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     permissions:
       issues: write
       pull-requests: write

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   golint:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v3
       - name: setup golang from container image
@@ -21,7 +21,7 @@ jobs:
           skip-build-cache: true # skip cache because of flaky behaviors
 
   commitlint:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/unit_test.yaml
+++ b/.github/workflows/unit_test.yaml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   unit-test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
      - uses: actions/checkout@v3
 


### PR DESCRIPTION
This is a scheduled Ubuntu 20.04 retirement.
Ubuntu 20.04 LTS runner will be removed on 2025-04-15.
For more details, see https://github.com/actions/runner-images/issues/11101